### PR TITLE
ThemeProvider with renderProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "0.30.1",
+    "version": "0.30.2",
     "private": false,
     "main": "dist/index.js",
     "module": "dist/index.es.js",

--- a/src/components/Element/constants.ts
+++ b/src/components/Element/constants.ts
@@ -2,7 +2,7 @@ import { HTMLProps } from "react";
 
 import { RFTheme } from "../../styles/theme";
 
-export type ThemeType = typeof RFTheme;
+export type ThemeType = Partial<typeof RFTheme>;
 
 export interface ThemeProps {
     theme ? : ThemeType;

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { ThemeProvider as TP } from "styled-components";
-import merge from "lodash/merge";
 
 import { Element } from "../Element/Element";
 import { CommonAndHTMLProps, ThemeProps } from "../Element/constants";
@@ -11,43 +10,34 @@ import { GlobalStaticStyled as StaticGlobalStyled } from "../../styles/GlobalSta
 
 
 export type ThemeProviderElementType = HTMLDivElement;
-export type ThemeLabel               = "light" | "dark";
-export type Theme                    = typeof RFTheme;
-export type LabelledThemes           = Record<ThemeLabel, Theme>;
+type RenderProps = () => JSX.Element;
 
-export interface GlobalStyledProps extends ThemeProps { }
-export interface ThemeProviderProps extends Omit<CommonAndHTMLProps<ThemeProviderElementType>, "theme"> {
-    theme : ThemeLabel
+export interface GlobalStyledProps extends ThemeProps { };
+export interface ThemeProviderProps extends CommonAndHTMLProps<ThemeProviderElementType> {
+    localStyled: RenderProps
+};
+
+export const ThemeProvider = ({
+    theme,
+    localStyled,
+    children,
+    ...props
+}: ThemeProviderProps) => {
+
+    return (
+        <>
+            {/* Styles that don't need to be computed */}
+            <StaticGlobalStyled />
+
+            <Element<ThemeProviderElementType>
+                as={TP}
+                theme={theme}
+                {...props}
+            >
+                <DynamicGlobalStyled />
+                {localStyled()}
+                {children}
+            </Element>
+        </>
+    );
 }
-
-export const CreateThemeProvider = (themes: LabelledThemes) => {
-    themes["light"] = merge({}, RFTheme, themes["light"]);
-    themes["dark"] = merge({}, RFTheme, themes["dark"]);
-    return ({
-        theme,
-        children,
-        ...props
-    }: ThemeProviderProps) => {
-        return (
-            <>
-                {/* Styles that don't need to be computed */}
-                <StaticGlobalStyled />
-
-                <Element<ThemeProviderElementType>
-                    as={TP}
-                    theme={themes[theme]}
-                    {...props}
-                >
-                    <DynamicGlobalStyled />
-                    {children}
-                </Element>
-            </>
-        );
-    }
-}
-
-// For backward compatibility
-export const ThemeProvider = CreateThemeProvider({
-    light : RFTheme,
-    dark  : RFTheme
-});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,10 +53,11 @@ import { Table } from "./components/Table/Table";
 
 import { CodeBlock } from "./components/CodeBlock/CodeBlock";
 
-import { CreateThemeProvider, ThemeProvider } from "./components/ThemeProvider/ThemeProvider";
+import { ThemeProvider } from "./components/ThemeProvider/ThemeProvider";
 import { ThemeType, ThemeProps } from "./components/Element/constants";
 
 import { baseColors } from "./styles/BaseColors";
+import {RFTheme } from "./styles/theme";
 
 export {
     Element,
@@ -99,8 +100,8 @@ export {
     NotificationItem,
     InfoPanel,
     CodeBlock,
-    CreateThemeProvider,
     ThemeProvider,
+    RFTheme,
     ThemeType,
     ThemeProps,
     baseColors


### PR DESCRIPTION
`CreateThemeProvider` has been ditched.
We will leave the state to be managed by the application side ( as a usecase may arise where-in the user selects a theme from a drop down ). 
Also, speed improvement while switching themes has been observed after passing <Styled/> component as a render Prop to `ThemeProvider`