### PR TITLE
Put back merge for theme into ThemeProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.30.6
+- Add merge to reduce size of custom overrides.
+
 # v0.30.5
 - Fix `a` tag hover colour bug.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # FICTOAN / React
-### v0.30.5
+### v0.30.6
 #### The React version of the FICTOAN framework

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "0.30.5",
+    "version": "0.30.6",
     "private": false,
     "main": "dist/index.js",
     "module": "dist/index.es.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,35 +9,40 @@ import pkg from "./package.json";
 const extensions = [".ts", ".tsx", ".js", ".jsx"];
 
 export default {
-    input: "src/index.tsx",
-    output: [
-        {
-            file: pkg.main,
-            format: "cjs",
-            sourcemap: true,
-            exports: "named"
-        },
-        {
-            file: pkg.module,
-            format: "es",
-            sourcemap: true,
-            exports: "named"
-        }
-    ],
-    external: [
-        "@types/lodash",
-        "@types/react",
-        "@types/styled-components",
-        "lodash/merge",
-        "react",
-        "styled-components"
-    ],
-    plugins: [
-        typescript(),
-        url(),
-        resolve({
-            extensions
-        }),
-        commonjs({ extensions })
-    ]
+  input: "src/index.tsx",
+  output: [
+    {
+      file: pkg.main,
+      format: "cjs",
+      sourcemap: true,
+      exports: "named",
+    },
+    {
+      file: pkg.module,
+      format: "es",
+      sourcemap: true,
+      exports: "named",
+    },
+  ],
+  external: [
+    "@types/lodash",
+    "@types/react",
+    "@types/styled-components",
+    "lodash/merge",
+    "react",
+    "styled-components",
+  ],
+  plugins: [
+    typescript(),
+    url(),
+    resolve({
+      extensions,
+    }),
+    commonjs({
+      extensions,
+      namedExports: {
+        "node_modules/lodash/lodash.js": ["merge"],
+      },
+    }),
+  ],
 };

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ThemeProvider as TP } from "styled-components";
+import { merge } from "lodash";
 
 import { Element } from "../Element/Element";
 import { CommonAndHTMLProps, ThemeProps } from "../Element/constants";
@@ -7,35 +8,37 @@ import { CommonAndHTMLProps, ThemeProps } from "../Element/constants";
 import { GlobalStyled as DynamicGlobalStyled } from "./Global.styled";
 import { GlobalStaticStyled as StaticGlobalStyled } from "../../styles/GlobalStatic.styled";
 
+import { RFTheme } from "../../styles/theme";
 
 export type ThemeProviderElementType = HTMLDivElement;
-export type RenderProps              = () => JSX.Element;
+export type RenderProps = () => JSX.Element;
 
-export interface GlobalStyledProps extends ThemeProps { };
-export interface ThemeProviderProps extends CommonAndHTMLProps<ThemeProviderElementType> {
-    localStyled ? : RenderProps;
+export interface GlobalStyledProps extends ThemeProps {}
+export interface ThemeProviderProps
+  extends CommonAndHTMLProps<ThemeProviderElementType> {
+  localStyled?: RenderProps;
 }
 
 export const ThemeProvider = ({
-    theme,
-    localStyled,
-    children,
-    ...props
+  theme,
+  localStyled,
+  children,
+  ...props
 }: ThemeProviderProps) => {
-    return (
-        <>
-            {/* Styles that don't need to be computed */}
-            <StaticGlobalStyled />
+  return (
+    <>
+      {/* Styles that don't need to be computed */}
+      <StaticGlobalStyled />
 
-            <Element<ThemeProviderElementType>
-                as={TP}
-                theme={theme}
-                {...props}
-            >
-                <DynamicGlobalStyled />
-                {localStyled && localStyled()}
-                {children}
-            </Element>
-        </>
-    );
-}
+      <Element<ThemeProviderElementType>
+        as={TP}
+        theme={merge({}, RFTheme, theme)}
+        {...props}
+      >
+        <DynamicGlobalStyled />
+        {localStyled && localStyled()}
+        {children}
+      </Element>
+    </>
+  );
+};


### PR DESCRIPTION
- The merge as such is not slow. On production/build, the theme switch is quick.
- Reintroducing merge back into Fictoan React helps users of Fictoan React to only specify overrides in their custom themes.