### PR TITLE
Memoize theme prop in ThemeProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.30.8
+- Memoize theme prop in ThemeProvider.
+
 # v0.30.7
 - Add missing props for theming some elements.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # FICTOAN / React
-### v0.30.7
+### v0.30.8
 #### The React version of the FICTOAN framework

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "0.30.7",
+    "version": "0.30.8",
     "private": false,
     "main": "dist/index.js",
     "module": "dist/index.es.js",

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -32,7 +32,7 @@ export const ThemeProvider = ({
 
             <Element<ThemeProviderElementType>
                 as={TP}
-                theme={merge({}, RFTheme, theme)}
+                theme={React.useMemo(() => merge({}, RFTheme, theme), [theme])}
                 {...props}
             >
                 <DynamicGlobalStyled/>


### PR DESCRIPTION
## Changes
###  Memoize theme prop in ThemeProvider
Currently, [ThemeProvider does a merge](https://github.com/fictoan/fictoan-react/blob/b7fe248bcb3c6fa4469e289c308a35d82701c52d/src/components/ThemeProvider/ThemeProvider.tsx#L35) (using [`lodash`](https://lodash.com/docs/4.17.15#merge)) of the theme prop passed and the default RFTheme object. This computation is expensive but has to happen only when the theme prop value changes. So use `React.useMemo` hook to memoize the result and avoid unnecessary re-renders (and computation of this value).