### PR TITLE
Fix unknown props being passed to the DOM

### DIFF
--- a/src/components/Element/BaseElement.tsx
+++ b/src/components/Element/BaseElement.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+
+import { createClassName } from "../../utils/classNames";
+
+import { ElementProps } from "./constants";
+
+export const BaseElement = React.forwardRef(
+    <K extends {}>(
+        {
+            as: Component,
+            className,
+            classNames = [],
+            size,
+            isFullWidth,
+            isFullHeight,
+            bgColor,
+            bgColour,
+            textColor,
+            textColour,
+            borderColor,
+            borderColour,
+            fillColor,
+            fillColour,
+            strokeColor,
+            strokeColour,
+            hideOnMobile,
+            showOnlyOnMobile,
+            hideOnTabPT,
+            showOnlyOnTabPT,
+            hideOnTabLS,
+            showOnlyOnTabLS,
+            hideOnDesktop,
+            showOnlyOnDesktop,
+            marginTop,
+            marginRight,
+            marginBottom,
+            marginLeft,
+            margin,
+            paddingTop,
+            paddingRight,
+            paddingBottom,
+            paddingLeft,
+            padding,
+            ...props
+        }: ElementProps<K>,
+        ref: React.LegacyRef<HTMLElement>
+    ) => {
+        return (
+            <Component
+                ref={ref}
+                {...props}
+                className={createClassName(
+                    [
+                        className,
+                        size && `size-${size}`,
+                        isFullWidth && "full-width",
+                        isFullHeight && "full-height",
+                        bgColor && `bg-${bgColor}`,
+                        bgColour && `bg-${bgColour}`,
+                        textColor && `text-${textColor}`,
+                        textColour && `text-${textColour}`,
+                        borderColor && `border-${borderColor}`,
+                        borderColour && `border-${borderColour}`,
+                        fillColor && `fill-${fillColor}`,
+                        fillColour && `fill-${fillColour}`,
+                        strokeColor && `stroke-${strokeColor}`,
+                        strokeColour && `stroke-${strokeColour}`,
+                        hideOnMobile && "hide-on-mobile",
+                        showOnlyOnMobile && "show-only-on-mobile",
+                        hideOnTabPT && "hide-on-tab-pt",
+                        showOnlyOnTabPT && "show-only-on-tab-pt",
+                        hideOnTabLS && "hide-on-tab-ls",
+                        showOnlyOnTabLS && "show-only-on-tab-ls",
+                        hideOnDesktop && "hide-on-desktop",
+                        showOnlyOnDesktop && "show-only-on-desktop",
+                        marginTop && `margin-top-${marginTop}`,
+                        marginRight && `margin-right-${marginRight}`,
+                        marginBottom && `margin-bottom-${marginBottom}`,
+                        marginLeft && `margin-left-${marginLeft}`,
+                        margin && `margin-all-${margin}`,
+                        paddingTop && `padding-top-${paddingTop}`,
+                        paddingRight && `padding-right-${paddingRight}`,
+                        paddingBottom && `padding-bottom-${paddingBottom}`,
+                        paddingLeft && `padding-left-${paddingLeft}`,
+                        padding && `padding-all-${padding}`,
+                    ].concat(classNames)
+                )}
+            />
+        );
+    }
+) as <K extends {}>(props: ElementProps<K> & { ref?: React.LegacyRef<HTMLElement> }) => React.ReactElement;

--- a/src/components/Element/Element.tsx
+++ b/src/components/Element/Element.tsx
@@ -1,86 +1,10 @@
 import React from "react";
 
-import { createClassName } from "../../utils/classNames";
-
+import { BaseElement } from "./BaseElement";
 import { ElementProps } from "./constants";
 
-export const Element = React.forwardRef(<K extends {}>(props: ElementProps<K>, ref: React.LegacyRef<HTMLElement>) => {
-    const {
-        size,
-        isFullWidth,
-        isFullHeight,
-        bgColor,
-        bgColour,
-        textColor,
-        textColour,
-        borderColor,
-        borderColour,
-        fillColor,
-        fillColour,
-        strokeColor,
-        strokeColour,
-        hideOnMobile,
-        showOnlyOnMobile,
-        hideOnTabPT,
-        showOnlyOnTabPT,
-        hideOnTabLS,
-        showOnlyOnTabLS,
-        hideOnDesktop,
-        showOnlyOnDesktop,
-        marginTop,
-        marginRight,
-        marginBottom,
-        marginLeft,
-        margin,
-        paddingTop,
-        paddingRight,
-        paddingBottom,
-        paddingLeft,
-        padding,
-    } = props;
-
-    const { as: Component, className, classNames = [], ...sanitizedProps } = props;
-
-    return (
-        <Component
-            ref={ref}
-            {...sanitizedProps}
-            className={createClassName(
-                [
-                    className,
-                    size && `size-${size}`,
-                    isFullWidth && "full-width",
-                    isFullHeight && "full-height",
-                    bgColor && `bg-${bgColor}`,
-                    bgColour && `bg-${bgColour}`,
-                    textColor && `text-${textColor}`,
-                    textColour && `text-${textColour}`,
-                    borderColor && `border-${borderColor}`,
-                    borderColour && `border-${borderColour}`,
-                    fillColor && `fill-${fillColor}`,
-                    fillColour && `fill-${fillColour}`,
-                    strokeColor && `stroke-${strokeColor}`,
-                    strokeColour && `stroke-${strokeColour}`,
-                    hideOnMobile && "hide-on-mobile",
-                    showOnlyOnMobile && "show-only-on-mobile",
-                    hideOnTabPT && "hide-on-tab-pt",
-                    showOnlyOnTabPT && "show-only-on-tab-pt",
-                    hideOnTabLS && "hide-on-tab-ls",
-                    showOnlyOnTabLS && "show-only-on-tab-ls",
-                    hideOnDesktop && "hide-on-desktop",
-                    showOnlyOnDesktop && "show-only-on-desktop",
-                    marginTop && `margin-top-${marginTop}`,
-                    marginRight && `margin-right-${marginRight}`,
-                    marginBottom && `margin-bottom-${marginBottom}`,
-                    marginLeft && `margin-left-${marginLeft}`,
-                    margin && `margin-all-${margin}`,
-                    paddingTop && `padding-top-${paddingTop}`,
-                    paddingRight && `padding-right-${paddingRight}`,
-                    paddingBottom && `padding-bottom-${paddingBottom}`,
-                    paddingLeft && `padding-left-${paddingLeft}`,
-                    padding && `padding-all-${padding}`,
-                ].concat(classNames)
-            )}
-        />
-    );
-}) as <K extends {}>(props: ElementProps<K> & { ref?: React.LegacyRef<HTMLElement> }) => React.ReactElement;
+export const Element = React.forwardRef(
+    <K extends {}>({ as: Component, ...props }: ElementProps<K>, ref: React.LegacyRef<HTMLElement>) => {
+        return <BaseElement<K> as={Component} ref={ref} {...props} />;
+    }
+) as <K extends {}>(props: ElementProps<K> & { ref?: React.LegacyRef<HTMLElement> }) => React.ReactElement;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { Element } from "./components/Element/Element";
+import { BaseElement as Element } from "./components/Element/BaseElement";
 
 import { Row } from "./components/Row/Row";
 import { Portion } from "./components/Portion/Portion";


### PR DESCRIPTION
As part of a recent change, to allow `ElementProps` to be accessible from styled-components, the `Element` component (on top of which every other component is built) started passing all props down to the DOM. This caused React to complain with the following error:
> React does not recognize the `<propname>` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `<propname>` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

Resolve this by having a `BaseElement` prop that ignores all custom props and export it as `Element`. For Fictoan internal use, have an extended component that passes all props to Component and let styled-components absorb it.