### PR TITLE
Update commands for installing dependencies and build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: '12.x'
-    - name: Install deps and build (with cache)
-      uses: bahmutov/npm-install@v1
+    - name: Install deps and build
+      uses: npm ci && npm run build
     - name: Publish if version has been updated
       uses: JS-DevTools/npm-publish@v1
       with: # Token is a required input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 0.42.3
+- Update command for installing dependencies and build in CI
+
 ### 0.42.2
 - Fix broken npm publish action
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "0.42.2",
+    "version": "0.42.3",
     "private": false,
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",


### PR DESCRIPTION
Change:
- Update command for installing deps and build (reverted to `npm ci` and `npm run build` instead of using github action)