### PR TITLE
Export props types for all components, fix extra margin issue for tab labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 0.45.1
+- Export props types for all components
+- Fix excess margin issue for `Tabs` labels
+
 ### 0.45.0
 - Add support for defaultTabIndex props in `Tabs` component because by default it select first tab as active tab
 

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -1,2 +1,2 @@
-export { Badge } from "./Badge";
+export { Badge, BadgeProps } from "./Badge";
 export { BadgeStyled } from "./Badge.styled";

--- a/src/components/BottomDrawer/index.tsx
+++ b/src/components/BottomDrawer/index.tsx
@@ -1,2 +1,2 @@
-export { BottomDrawer } from "./BottomDrawer";
+export { BottomDrawer, BottomDrawerProps } from "./BottomDrawer";
 export { BottomDrawerStyled } from "./BottomDrawer.styled";

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -1,5 +1,5 @@
-export { BreadcrumbsWrapper } from "./BreadcrumbsWrapper/BreadcrumbsWrapper";
+export { BreadcrumbsWrapper, BreadcrumbsWrapperProps } from "./BreadcrumbsWrapper/BreadcrumbsWrapper";
 export { BreadcrumbsWrapperStyled } from "./BreadcrumbsWrapper/BreadcrumbsWrapper.styled";
 
-export { BreadcrumbItem } from "./BreadcrumbItem/BreadcrumbItem";
+export { BreadcrumbItem, BreadcrumbItemProps } from "./BreadcrumbItem/BreadcrumbItem";
 export { BreadcrumbItemStyled } from "./BreadcrumbItem/BreadcrumbItem.styled";

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,2 +1,2 @@
-export { Button } from "./Button";
+export { Button, ButtonProps } from "./Button";
 export { ButtonStyled } from "./Button.styled";

--- a/src/components/Callout/index.tsx
+++ b/src/components/Callout/index.tsx
@@ -1,2 +1,2 @@
-export { Callout } from "./Callout";
+export { Callout, CalloutProps } from "./Callout";
 export { CalloutStyled } from "./Callout.styled";

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,2 +1,2 @@
-export { Card } from "./Card";
+export { Card, CardProps } from "./Card";
 export { CardStyled } from "./Card.styled";

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -1,2 +1,2 @@
-export { CodeBlock } from "./CodeBlock";
-export { CodeStyled } from "./Code.styled";
+export { CodeBlock, CodeBlockProps } from "./CodeBlock";
+export { CodeStyled as CodeBlockStyled } from "./Code.styled";

--- a/src/components/ContentWrapper/index.tsx
+++ b/src/components/ContentWrapper/index.tsx
@@ -1,2 +1,2 @@
-export { ContentWrapper } from "./ContentWrapper";
+export { ContentWrapper, ContentWrapperProps } from "./ContentWrapper";
 export { ContentWrapperStyled } from "./ContentWrapper.styled";

--- a/src/components/Element/index.tsx
+++ b/src/components/Element/index.tsx
@@ -1,1 +1,2 @@
 export { Element } from "./Element";
+export { ElementProps, CommonAndHTMLProps } from "./constants";

--- a/src/components/ExpandableContent/index.tsx
+++ b/src/components/ExpandableContent/index.tsx
@@ -1,2 +1,2 @@
-export { ExpandableContent } from "./ExpandableContent";
+export { ExpandableContent, ExpandableContentProps } from "./ExpandableContent";
 export { ExpandableContentStyled } from "./ExpandableContent.styled";

--- a/src/components/Form/InputField/FileUpload.tsx
+++ b/src/components/Form/InputField/FileUpload.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { InputField } from "./InputField";
 import { InputFieldProps } from "./InputField";
 
-export const FileUpload = React.forwardRef(({ ...props }: InputFieldProps, ref: React.Ref<HTMLInputElement>) => {
+export type FileUploadProps = InputFieldProps;
+export const FileUpload = React.forwardRef(({ ...props }: FileUploadProps, ref: React.Ref<HTMLInputElement>) => {
     return <InputField type="file" ref={ref} {...props} />;
 });

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -1,32 +1,33 @@
-export { FormWrapper } from "./FormWrapper/FormWrapper";
+export { FormWrapper, FormWrapperProps } from "./FormWrapper/FormWrapper";
 export { FormWrapperStyled } from "./FormWrapper/FormWrapper.styled";
 
-export { FormItem } from "./FormItem/FormItem";
+export { FormItem, FormItemProps } from "./FormItem/FormItem";
 export { FormItemStyled } from "./FormItem/FormItem.styled";
 
-export { FormItemGroup } from "./FormItemGroup/FormItemGroup";
+export { FormItemGroup, FormItemGroupProps } from "./FormItemGroup/FormItemGroup";
 export { FormItemGroupStyled } from "./FormItemGroup/FormItemGroup.styled";
 
-export { InputField } from "./InputField/InputField";
+export { InputField, InputFieldProps } from "./InputField/InputField";
 export { InputFieldStyled } from "./InputField/InputField.styled";
 
-export { TextArea } from "./TextArea/TextArea";
+export { TextArea, TextareaProps } from "./TextArea/TextArea";
 export { TextAreaStyled } from "./TextArea/TextArea.styled";
 
-export { InputLabel } from "./InputLabel/InputLabel";
+export { InputLabel, InputLabelProps } from "./InputLabel/InputLabel";
 
-export { Select } from "./Select/Select";
+export { Select, SelectProps } from "./Select/Select";
 export { SelectStyled } from "./Select/Select.styled";
 
-export { FileUpload } from "./InputField/FileUpload";
+export { FileUpload, FileUploadProps } from "./InputField/FileUpload";
 
 export { RadioGroup } from "./RadioButton/RadioGroup";
+export { RadioButtonProps, RadioGroupProps } from "./RadioButton/constants";
 
 export { RadioButton } from "./RadioButton/RadioButton";
 export { RadioButtonStyled } from "./RadioButton/RadioButton.styled";
 
-export { CheckBox } from "./CheckBox/CheckBox";
+export { CheckBox, CheckboxProps } from "./CheckBox/CheckBox";
 export { CheckBoxStyled } from "./CheckBox/CheckBox.styled";
 
-export { Switch } from "./CheckBox/Switch";
+export { Switch, SwitchProps } from "./CheckBox/Switch";
 export { SwitchStyled } from "./CheckBox/CheckBox.styled";

--- a/src/components/HRule/index.tsx
+++ b/src/components/HRule/index.tsx
@@ -1,2 +1,2 @@
-export { HRule } from "./HRule";
+export { HRule, HRProps as HRuleProps } from "./HRule";
 export { HRuleStyled } from "./HRule.styled";

--- a/src/components/InfoPanel/index.tsx
+++ b/src/components/InfoPanel/index.tsx
@@ -1,2 +1,2 @@
-export { InfoPanel } from "./InfoPanel";
+export { InfoPanel, InfoPanelProps } from "./InfoPanel";
 export { InfoPanelStyled } from "./InfoPanel.styled";

--- a/src/components/Notification/index.tsx
+++ b/src/components/Notification/index.tsx
@@ -1,5 +1,5 @@
-export { NotificationsWrapper } from "./NotificationsWrapper/NotificationsWrapper";
+export { NotificationsWrapper, NotificationsWrapperProps } from "./NotificationsWrapper/NotificationsWrapper";
 export { NotificationsWrapperStyled } from "./NotificationsWrapper/NotificationsWrapper.styled";
 
-export { NotificationItem } from "./NotificationItem/NotificationItem";
+export { NotificationItem, NotificationItemProps } from "./NotificationItem/NotificationItem";
 export { NotificationItemStyled } from "./NotificationItem/NotificationItem.styled";

--- a/src/components/PinInputField/index.tsx
+++ b/src/components/PinInputField/index.tsx
@@ -1,2 +1,2 @@
-export { PinInputField } from "./PinInputField";
+export { PinInputField, PinInputFieldProps } from "./PinInputField";
 export { PinInputStyled } from "./PinInputField.styled";

--- a/src/components/Portion/index.tsx
+++ b/src/components/Portion/index.tsx
@@ -1,2 +1,2 @@
-export { Portion } from "./Portion";
+export { Portion, PortionProps } from "./Portion";
 export { PortionStyled } from "./Portion.styled";

--- a/src/components/ProgressBar/index.tsx
+++ b/src/components/ProgressBar/index.tsx
@@ -1,2 +1,2 @@
-export { ProgressBar } from "./ProgressBar";
+export { ProgressBar, ProgressBarProps } from "./ProgressBar";
 export { ProgressBarStyled } from "./ProgressBar.styled";

--- a/src/components/Row/index.tsx
+++ b/src/components/Row/index.tsx
@@ -1,2 +1,2 @@
-export { Row } from "./Row";
+export { Row, RowProps } from "./Row";
 export { RowStyled } from "./Row.styled";

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,17 +1,17 @@
-export { SidebarWrapper } from "./SidebarWrapper/SidebarWrapper";
+export { SidebarWrapper, SidebarWrapperProps } from "./SidebarWrapper/SidebarWrapper";
 export { SidebarWrapperStyled } from "./SidebarWrapper/SidebarWrapper.styled";
 
-export { SidebarHeader } from "./SidebarHeader/SidebarHeader";
+export { SidebarHeader, SidebarHeaderProps } from "./SidebarHeader/SidebarHeader";
 export { SidebarHeaderStyled } from "./SidebarHeader/SidebarHeader.styled";
 
-export { SidebarItem } from "./SidebarItem/SidebarItem";
+export { SidebarItem, SidebarItemProps } from "./SidebarItem/SidebarItem";
 export { SidebarItemStyled } from "./SidebarItem/SidebarItem.styled";
 
-export { SidebarItemIcon } from "./SidebarItemIcon/SidebarItemIcon";
+export { SidebarItemIcon, SidebarItemIconProps } from "./SidebarItemIcon/SidebarItemIcon";
 export { SidebarItemIconStyled } from "./SidebarItemIcon/SidebarItemIcon.styled";
 
-export { SidebarItemText } from "./SidebarItemText/SidebarItemText";
+export { SidebarItemText, SidebarItemTextProps } from "./SidebarItemText/SidebarItemText";
 export { SidebarItemTextStyled } from "./SidebarItemText/SidebarItemText.styled";
 
-export { SidebarFooter } from "./SidebarFooter/SidebarFooter";
+export { SidebarFooter, SidebarFooterProps } from "./SidebarFooter/SidebarFooter";
 export { SidebarFooterStyled } from "./SidebarFooter/SidebarFooter.styled";

--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -1,2 +1,2 @@
-export { Spinner } from "./Spinner";
+export { Spinner, SpinnerProps } from "./Spinner";
 export { SpinnerStyled } from "./Spinner.styled";

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -1,0 +1,5 @@
+export { Table, TableProps } from "./Table";
+export { TableStyled } from "./Table.styled";
+
+export { TablePagination, TablePaginationProps } from "./TablePagination/TablePagination";
+export { TablePaginationStyled } from "./TablePagination/TablePagination.styled";

--- a/src/components/Tabs/Tabs.styled.tsx
+++ b/src/components/Tabs/Tabs.styled.tsx
@@ -7,6 +7,7 @@ export const TabsStyled = styled.section`
         align-items : center;
 
         ul.tab-labels-list {
+            margin  : 0;
             padding : 0;
             display : flex;
 

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,2 +1,2 @@
-export { Tabs } from "./Tabs";
+export { Tabs, TabsProps } from "./Tabs";
 export { TabsStyled } from "./Tabs.styled";

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -1,5 +1,5 @@
-export { ToastsWrapper } from "./ToastsWrapper/ToastsWrapper";
+export { ToastsWrapper, NotificationsWrapperProps as ToastsWrapperProps } from "./ToastsWrapper/ToastsWrapper";
 export { ToastsWrapperStyled } from "./ToastsWrapper/ToastsWrapper.styled";
 
-export { ToastItem } from "./ToastItem/ToastItem";
+export { ToastItem, ToastItemProps } from "./ToastItem/ToastItem";
 export { ToastItemStyled } from "./ToastItem/ToastItem.styled";

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,2 +1,2 @@
-export { Tooltip } from "./Tooltip";
+export { Tooltip, TooltipProps } from "./Tooltip";
 export { TooltipStyled } from "./Tooltip.styled";

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -1,3 +1,3 @@
-export { Text } from "./Text";
-export { Heading } from "./Heading";
+export { Text, TextProps } from "./Text";
+export { Heading, HeadingProps } from "./Heading";
 export { TypographyStyled } from "./Typography.styled";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,104 +1,110 @@
 // BADGE  /////////////////////////////////////////////////////////////////////
-export { Badge, BadgeStyled } from "./components/Badge";
+export { Badge, BadgeStyled, BadgeProps } from "./components/Badge";
 
 // BOTTOM DRAWER  /////////////////////////////////////////////////////////////
-export { BottomDrawer, BottomDrawerStyled } from "./components/BottomDrawer";
+export { BottomDrawer, BottomDrawerStyled, BottomDrawerProps } from "./components/BottomDrawer";
 
 // BREADCRUMBS  ///////////////////////////////////////////////////////////////
 export {
-    BreadcrumbsWrapper, BreadcrumbsWrapperStyled,
-    BreadcrumbItem, BreadcrumbItemStyled
+    BreadcrumbsWrapper, BreadcrumbsWrapperStyled, BreadcrumbsWrapperProps,
+    BreadcrumbItem, BreadcrumbItemStyled, BreadcrumbItemProps
 } from "./components/Breadcrumbs";
 
 // BUTTON  ////////////////////////////////////////////////////////////////////
-export { Button, ButtonStyled } from "./components/Button";
+export { Button, ButtonStyled, ButtonProps } from "./components/Button";
 
 // CALLOUT  ///////////////////////////////////////////////////////////////////
-export { Callout, CalloutStyled } from "./components/Callout";
+export { Callout, CalloutStyled, CalloutProps } from "./components/Callout";
 
 // CARD  //////////////////////////////////////////////////////////////////////
-export { Card, CardStyled } from "./components/Card";
+export { Card, CardStyled, CardProps } from "./components/Card";
 
 // CODE  //////////////////////////////////////////////////////////////////////
-export { CodeBlock, CodeStyled } from "./components/CodeBlock";
+export { CodeBlock, CodeBlockStyled, CodeBlockProps } from "./components/CodeBlock";
 
 // ELEMENT  ///////////////////////////////////////////////////////////////////
-export { Element } from "./components/Element";
+export { Element, ElementProps, CommonAndHTMLProps } from "./components/Element";
 
 // ACCORDION  /////////////////////////////////////////////////////////////////
-export { ExpandableContent, ExpandableContentStyled } from "./components/ExpandableContent";
+export { ExpandableContent, ExpandableContentStyled, ExpandableContentProps } from "./components/ExpandableContent";
 
 // H-RULE  ////////////////////////////////////////////////////////////////////
-export { HRule, HRuleStyled } from "./components/HRule";
+export { HRule, HRuleStyled, HRuleProps } from "./components/HRule";
 
 // FORM  //////////////////////////////////////////////////////////////////////
 export {
-    FormWrapper, FormWrapperStyled,
-    FormItem, FormItemStyled,
-    FormItemGroup, FormItemGroupStyled,
-    InputField, InputFieldStyled,
-    TextArea, TextAreaStyled,
-    InputLabel,
-    Select, SelectStyled,
-    FileUpload,
-    RadioGroup,
-    RadioButton, RadioButtonStyled,
-    CheckBox, CheckBoxStyled,
-    Switch, SwitchStyled
+    FormWrapper, FormWrapperStyled, FormWrapperProps,
+    FormItem, FormItemStyled, FormItemProps, 
+    FormItemGroup, FormItemGroupStyled, FormItemGroupProps,
+    InputField, InputFieldStyled, InputFieldProps,
+    TextArea, TextAreaStyled, TextareaProps,
+    InputLabel, InputLabelProps,
+    Select, SelectStyled, SelectProps,
+    FileUpload, FileUploadProps,
+    RadioGroup, RadioGroupProps,
+    RadioButton, RadioButtonStyled, RadioButtonProps,
+    CheckBox, CheckBoxStyled, CheckboxProps,
+    Switch, SwitchStyled, SwitchProps
 } from "./components/Form";
 
 // LAYOUT  ////////////////////////////////////////////////////////////////////
-export { Row, RowStyled } from "./components/Row";
-export { Portion, PortionStyled } from "./components/Portion";
+export { Row, RowStyled, RowProps } from "./components/Row";
+export { Portion, PortionStyled, PortionProps } from "./components/Portion";
 
 // INFO PANEL  ////////////////////////////////////////////////////////////////
-export { InfoPanel, InfoPanelStyled } from "./components/InfoPanel";
+export { InfoPanel, InfoPanelStyled, InfoPanelProps } from "./components/InfoPanel";
 
 // NOTIFICATIONS  /////////////////////////////////////////////////////////////
 export {
-    NotificationsWrapper, NotificationsWrapperStyled,
-    NotificationItem, NotificationItemStyled
+    NotificationsWrapper, NotificationsWrapperStyled, NotificationsWrapperProps,
+    NotificationItem, NotificationItemStyled, NotificationItemProps
 } from "./components/Notification";
 
 // PIN INPUT FIELD  ///////////////////////////////////////////////////////////
-export { PinInputField, PinInputStyled } from "./components/PinInputField";
+export { PinInputField, PinInputStyled, PinInputFieldProps } from "./components/PinInputField";
 
 // PROGRESS BAR  //////////////////////////////////////////////////////////////
-export { ProgressBar, ProgressBarStyled } from "./components/ProgressBar";
+export { ProgressBar, ProgressBarStyled, ProgressBarProps } from "./components/ProgressBar";
 
 // SIDEBAR and CONTENT WRAPPER ////////////////////////////////////////////////
 export {
-    SidebarWrapper, SidebarWrapperStyled,
-    SidebarHeader, SidebarHeaderStyled,
-    SidebarItem, SidebarItemStyled,
-    SidebarItemIcon, SidebarItemIconStyled,
-    SidebarItemText, SidebarItemTextStyled,
-    SidebarFooter, SidebarFooterStyled
+    SidebarWrapper, SidebarWrapperStyled, SidebarWrapperProps,
+    SidebarHeader, SidebarHeaderStyled, SidebarHeaderProps,
+    SidebarItem, SidebarItemStyled, SidebarItemProps,
+    SidebarItemIcon, SidebarItemIconStyled, SidebarItemIconProps,
+    SidebarItemText, SidebarItemTextStyled, SidebarItemTextProps,
+    SidebarFooter, SidebarFooterStyled, SidebarFooterProps
 } from "./components/Sidebar";
 
-export { ContentWrapper, ContentWrapperStyled } from "./components/ContentWrapper";
+export { ContentWrapper, ContentWrapperStyled, ContentWrapperProps } from "./components/ContentWrapper";
 
 // SPINNER  ///////////////////////////////////////////////////////////////////
-export { Spinner, SpinnerStyled } from "./components/Spinner";
+export { Spinner, SpinnerStyled, SpinnerProps } from "./components/Spinner";
 
 // TABLE  /////////////////////////////////////////////////////////////////////
-export { Table } from "./components/Table/Table";
-export { TablePagination } from "./components/Table/TablePagination/TablePagination";
+export { 
+    Table, TableStyled, TableProps,
+    TablePagination, TablePaginationStyled, TablePaginationProps
+} from "./components/Table";
 
 // TABS  //////////////////////////////////////////////////////////////////////
-export { Tabs, TabsStyled } from "./components/Tabs";
+export { Tabs, TabsStyled, TabsProps } from "./components/Tabs";
 
-// TEXT  //////////////////////////////////////////////////////////////////////
-export { Text, Heading, TypographyStyled } from "./components/Typography";
+// TYPOGRAPHY  //////////////////////////////////////////////////////////////////////
+export { 
+    Text, TextProps,
+    Heading, HeadingProps,
+    TypographyStyled
+} from "./components/Typography";
 
 // TOAST  /////////////////////////////////////////////////////////////////////
 export {
-    ToastsWrapper, ToastsWrapperStyled,
-    ToastItem, ToastItemStyled
+    ToastsWrapper, ToastsWrapperStyled, ToastsWrapperProps,
+    ToastItem, ToastItemStyled, ToastItemProps
 } from "./components/Toast";
 
 // TOOLTIP  ///////////////////////////////////////////////////////////////////
-export { Tooltip, TooltipStyled } from "./components/Tooltip";
+export { Tooltip, TooltipStyled, TooltipProps } from "./components/Tooltip";
 
 // THEME  /////////////////////////////////////////////////////////////////////
 export { defaultColours } from "./styles/DefaultColours";


### PR DESCRIPTION
Changes:
 - export props types for all components (`ElementProps`, `RowProps`, `ButtonProps` etc.). This gives more flexibility to create custom components, extending on Fictoan components.
 - minor styling fix for `Tabs`, remove extra margin for tab labels list.