### PR TITLE
Fix pin input prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ### 0.45.1
+- Fix prop name for disable copy/paste to pasteFromClipboard which takes either enabled or disabled as parameters for `PinInput Field`
+
+### 0.45.1
 - Export props types for all components
 - Fix excess margin issue for `Tabs` labels
 - Add toggle for disabling copy/paste functionality in the `PinInputField` component 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-### 0.45.1
+### 0.45.2
 - Fix prop name for disable copy/paste to pasteFromClipboard which takes either enabled or disabled as parameters for `PinInput Field`
 
 ### 0.45.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "0.45.1",
+    "version": "0.45.2",
     "private": false,
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",

--- a/src/components/PinInputField/PinInputField.tsx
+++ b/src/components/PinInputField/PinInputField.tsx
@@ -8,14 +8,14 @@ import { PinInputStyled } from "./PinInputField.styled";
 
 // prettier-ignore
 type PinInputFieldCustomProps = {
-    numberOfFields   : number;
-    onChange       ? : (value : string) => void;
-    type           ? : "alphanumeric" | "number";
-    mask           ? : boolean;
-    otp            ? : boolean;
-    autoFocus      ? : boolean;
-    disableCopyPaste      ? : boolean;
-    spacing        ? : SpacingTypes;
+    numberOfFields       : number;
+    onChange           ? : (value : string) => void;
+    type               ? : "alphanumeric" | "number";
+    mask               ? : boolean;
+    otp                ? : boolean;
+    autoFocus          ? : boolean;
+    pasteFromClipboard ? : "enabled" | "disabled";
+    spacing            ? : SpacingTypes;
 };
 
 export type PinInputFieldElementType = HTMLDivElement;
@@ -38,7 +38,7 @@ export const PinInputField = React.forwardRef(
             mask = false,
             otp = false,
             autoFocus = false,
-            disableCopyPaste = false,
+            pasteFromClipboard = "enabled",
             spacing = "small",
         }: PinInputFieldProps,
         ref: React.Ref<PinInputFieldElementType>
@@ -199,8 +199,8 @@ export const PinInputField = React.forwardRef(
                         autoComplete={otp ? "one-time-code" : "off"}
                         value={values[i] || ""}
                         autoFocus={autoFocus && i === 0}
-                        onCopy={e=> disableCopyPaste && e.preventDefault()}
-                        onPaste={e=> disableCopyPaste && e.preventDefault()}
+                        onCopy={e=> pasteFromClipboard === "disabled" && e.preventDefault()}
+                        onPaste={e=> pasteFromClipboard === "disabled" && e.preventDefault()}
                     />
                 ))}
             </Element>


### PR DESCRIPTION
For **PinInputField** the prop `disableCopyPaste` was ambiguous for a user, so renamed the prop name to `pasteFromClipbaord` which takes in either of the two string values "enabled" or "disabled"