### PR TITLE
Hide notification wrapper when there are no notification items

### DIFF
--- a/src/components/Notification/NotificationsWrapper/NotificationsWrapper.styled.tsx
+++ b/src/components/Notification/NotificationsWrapper/NotificationsWrapper.styled.tsx
@@ -5,12 +5,14 @@ import { NotificationItemStyled } from "../NotificationItem/NotificationItem.sty
 
 export const NotificationsWrapperStyled = styled.div`
     position   : fixed;
-    display    : flex;
     width      : 400px;
     z-index    : 5000000;
     padding    : 2vw;
     overflow-y : auto;
     overflow-x : hidden;
+
+    &.show { display    : flex; }
+    &.hide { display    : none; }
 
     &.left  { left : 0; }
     

--- a/src/components/Notification/NotificationsWrapper/NotificationsWrapper.tsx
+++ b/src/components/Notification/NotificationsWrapper/NotificationsWrapper.tsx
@@ -23,6 +23,13 @@ export const NotificationsWrapper = React.forwardRef(
     ) => {
         let classNames = [];
 
+        if(ref.current.childElementCount > 0){
+            classNames.push(show)
+        }
+        else{
+            classNames.push(hide)
+        }
+
         if (position) {
             classNames.push(position);
         }

--- a/src/components/Notification/NotificationsWrapper/NotificationsWrapper.tsx
+++ b/src/components/Notification/NotificationsWrapper/NotificationsWrapper.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { createRef } from "react";
 
 import { Element } from "../../Element/Element";
 import { CommonAndHTMLProps } from "../../Element/constants";
@@ -21,13 +21,17 @@ export const NotificationsWrapper = React.forwardRef(
         { position = "right", anchor = "top", order = "new-on-top", ...props }: NotificationsWrapperProps,
         ref: React.Ref<NotificationsWrapperElementType>
     ) => {
-        let classNames = [];
+        let classNames = ["hide"];
 
-        if(ref.current.childElementCount > 0){
-            classNames.push(show)
+        const notificationsWrapperNode = createRef<HTMLDivElement>()
+
+        if(notificationsWrapperNode.current.childElementCount > 0){
+            classNames = classNames.filter(item => item!="hide")
+            classNames.push("show")
         }
         else{
-            classNames.push(hide)
+            classNames = classNames.filter(item => item!="show")
+            classNames.push("hide")
         }
 
         if (position) {


### PR DESCRIPTION
This prevents the notification wrapper from covering items under it, when there are no notifications being shown.

I haven't changed the version because I am not confident of how to do it.