### PR TITLE
Fix behaviour on paste or replace at position

### DIFF
--- a/src/components/PinInputField/PinInputField.stories.tsx
+++ b/src/components/PinInputField/PinInputField.stories.tsx
@@ -34,6 +34,5 @@ export const Default: FictoanStory<typeof PinInputField> = createStoryFromTempla
 Default.args = {
     numberOfFields: 4,
     type: "number",
-    mask: true,
     otp: true,
 };

--- a/src/components/PinInputField/PinInputField.tsx
+++ b/src/components/PinInputField/PinInputField.tsx
@@ -119,20 +119,16 @@ export const PinInputField = React.forwardRef(
                     // In all cases, we need to ensure characters longer than the remaining fields are removed.
                     if (currentValue == "") {
                         // Case: Current input field is empty
-                        nextValue = eventValue.split("").filter((_, index) => i + index < length);
+                        nextValue = eventValue.split("").filter((_, j) => i + j < length);
                     } else if (event.currentTarget.selectionEnd === eventValue.length) {
                         // Case: Current field has a value and cursor is after it
-                        nextValue = eventValue.split("").filter((_, index) => index > 0 && i + index - 1 < length);
+                        nextValue = eventValue.split("").filter((_, j) => j > 0 && i + j - 1 < length);
                     } else {
                         // Case: Current field has a value and cursor is before it
-                        nextValue = eventValue
-                            .split("")
-                            .filter((_, index) => index < eventValue.length - 1 && i + index < length);
+                        nextValue = eventValue.split("").filter((_, j) => j < eventValue.length - 1 && i + j < length);
                     }
                     setValues((values) =>
-                        values.map((v, index) =>
-                            index >= i && index < i + nextValue.length ? nextValue[index - i] : v
-                        )
+                        values.map((v, j) => (j >= i && j < i + nextValue.length ? nextValue[j - i] : v))
                     );
                     focus(i + nextValue.length < length ? i + nextValue.length : length - 1);
                     onChange?.(nextValue.join(""));

--- a/src/components/PinInputField/PinInputField.tsx
+++ b/src/components/PinInputField/PinInputField.tsx
@@ -103,34 +103,42 @@ export const PinInputField = React.forwardRef(
             [focusNext, length, onChange, values]
         );
 
-        const handleInputChange = (event: React.FormEvent<HTMLInputElement>, i: number) => {
+        const handleInputChange = (event: React.FormEvent<HTMLInputElement>, inputFieldIndex: number) => {
             const eventValue = event.currentTarget.value;
-            const currentValue = values[i];
+            const currentValue = values[inputFieldIndex];
 
             if (eventValue === "") {
-                setValue("", i);
+                setValue("", inputFieldIndex);
                 return;
             }
 
             // Handle scenario where multiple characters are entered in a single InputField
-            if (eventValue.length > 1 && i < length - 1) {
+            if (eventValue.length > 1 && inputFieldIndex < length - 1) {
                 if (validate(eventValue, type)) {
                     let nextValue: string[] = [];
                     // In all cases, we need to ensure characters longer than the remaining fields are removed.
                     if (currentValue == "") {
                         // Case: Current input field is empty
-                        nextValue = eventValue.split("").filter((_, j) => i + j < length);
+                        nextValue = eventValue.split("").filter((_, j) => inputFieldIndex + j < length);
                     } else if (event.currentTarget.selectionEnd === eventValue.length) {
                         // Case: Current field has a value and cursor is after it
-                        nextValue = eventValue.split("").filter((_, j) => j > 0 && i + j - 1 < length);
+                        nextValue = eventValue.split("").filter((_, j) => j > 0 && inputFieldIndex + j - 1 < length);
                     } else {
                         // Case: Current field has a value and cursor is before it
-                        nextValue = eventValue.split("").filter((_, j) => j < eventValue.length - 1 && i + j < length);
+                        nextValue = eventValue
+                            .split("")
+                            .filter((_, j) => j < eventValue.length - 1 && inputFieldIndex + j < length);
                     }
                     setValues((values) =>
-                        values.map((v, j) => (j >= i && j < i + nextValue.length ? nextValue[j - i] : v))
+                        values.map((v, j) =>
+                            j >= inputFieldIndex && j < inputFieldIndex + nextValue.length
+                                ? nextValue[j - inputFieldIndex]
+                                : v
+                        )
                     );
-                    focus(i + nextValue.length < length ? i + nextValue.length : length - 1);
+                    focus(
+                        inputFieldIndex + nextValue.length < length ? inputFieldIndex + nextValue.length : length - 1
+                    );
                     onChange?.(nextValue.join(""));
                 }
             } else {
@@ -143,7 +151,7 @@ export const PinInputField = React.forwardRef(
                     }
                 }
                 if (validate(nextValue, type)) {
-                    setValue(nextValue, i);
+                    setValue(nextValue, inputFieldIndex);
                 }
             }
         };

--- a/src/components/PinInputField/PinInputField.tsx
+++ b/src/components/PinInputField/PinInputField.tsx
@@ -125,8 +125,12 @@ export const PinInputField = React.forwardRef(
 
             if (eventValue.length > 1 && i < length - 1) {
                 if (validate(eventValue, type)) {
-                    const nextValue = eventValue.split("").filter((_, index) => index < length);
-                    setValues(nextValue);
+                    const nextValue = eventValue.split("").filter((_, index) => index > 0 && i + index - 1 < length);
+                    setValues((values) =>
+                        values.map((v, index) =>
+                            index >= i && index < i + nextValue.length ? nextValue[index - i] : v
+                        )
+                    );
                     focus(i + nextValue.length < length ? i + nextValue.length : length - 1);
                     onChange?.(nextValue.join(""));
                 }
@@ -199,8 +203,8 @@ export const PinInputField = React.forwardRef(
                         autoComplete={otp ? "one-time-code" : "off"}
                         value={values[i] || ""}
                         autoFocus={autoFocus && i === 0}
-                        onCopy={e=> pasteFromClipboard === "disabled" && e.preventDefault()}
-                        onPaste={e=> pasteFromClipboard === "disabled" && e.preventDefault()}
+                        onCopy={(e) => pasteFromClipboard === "disabled" && e.preventDefault()}
+                        onPaste={(e) => pasteFromClipboard === "disabled" && e.preventDefault()}
                     />
                 ))}
             </Element>


### PR DESCRIPTION
Earlier, whenever a string was pasted into any of the InputFields used under PinInputField, the values were always replaced starting from the first PinInputField due to simply setting setValues. The ideal behaviour though would be to paste the value only starting from the InputField that is focused before pasting. An alternate scenario where this bug also existed was when any of the InputFields were focused and multiple characters were entered and the same behaviour of setting the value starting with the first InputField occurred.

Fix this behaviour by essentially replacing the values state with the multi-character input starting only from the focused index.

Additionally, also fix the issue where focus doesn't shift when an InputElement with an existing value is cleared and a new value is entered.