### PR TITLE
v0.46.5: Add imperative reset handler for PinInputField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.46.5
 - Add an imperative reset handler to reset `PinInputField` from the parent component with ref.
+- Adds a `focusFirstInputOnReset` prop for the above change, to opt out of focusing on first input on reset.
 
 ### 0.45.5
 - Add Tab component label prop to be used as reactnode for custom label

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # CHANGELOG
 
+### 0.46.5
+- Add an imperative reset handler to reset `PinInputField` from the parent component with ref.
+
 ### 0.45.5
 - Add Tab component label prop to be used as reactnode for custom label
+
 ### 0.45.4
 - Fix PinInputField behaviour on paste or replace at position
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
 ### 0.46.5
-- Add an imperative reset handler to reset `PinInputField` from the parent component with ref.
-- Adds a `focusFirstInputOnReset` prop for the above change, to opt out of focusing on first input on reset.
+- Add an imperative reset handler to reset `PinInputField` from the parent component with ref
+- Add a `focusFirstInputOnReset` prop for the above change, to opt out of focusing on first input on reset
 
 ### 0.45.5
 - Add Tab component label prop to be used as reactnode for custom label

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "0.45.5",
+    "version": "0.46.5",
     "private": false,
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",


### PR DESCRIPTION
Changes:
- Adds an imperative reset handler for `PinInputField` to give the ability to reset the pin input from a parent component, like so:

```tsx
const inputRef = useRef<PinInputElementType>(); // Type needed for TS

<InputWrapper>
    <PinInputField ref={inputRef} {...other props} />
    
    <Button onClick={input.current.reset()}>Resend OTP</Button>
</InputWrapper>
```
- Adds an optional `focusFirstInputOnReset` prop to opt-out of resetting the first input on reset (enabled by default)