### PR TITLE
v0.46.6: Export custom PinInputField element type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 0.46.6
+- Export custom `PinInputFieldElementType` for supporting custom ref types in TypeScript
+
 ### 0.46.5
 - Add an imperative reset handler to reset `PinInputField` from the parent component with ref
 - Add a `focusFirstInputOnReset` prop for the above change, to opt out of focusing on first input on reset

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "0.46.5",
+    "version": "0.46.6",
     "private": false,
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",

--- a/src/components/PinInputField/index.tsx
+++ b/src/components/PinInputField/index.tsx
@@ -1,2 +1,2 @@
-export { PinInputField, PinInputFieldProps } from "./PinInputField";
+export { PinInputField, PinInputFieldProps,PinInputFieldElementType } from "./PinInputField";
 export { PinInputStyled } from "./PinInputField.styled";


### PR DESCRIPTION
Changes:
- Export custom PinInputField element type. This would help in using the changes in #105 in TS, like this:
```tsx
import { PinInputField, PinInputFieldElementType } from 'fictoan-react';

const pinInputRef = useRef<PinInputFieldElementType>(); // type-safe ref creation

return  <PinInputField ref={pinInputRef} {...other props} />
```
