### PR TITLE
Export custom `PinInputFieldElementType` for typesafe ref usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-### 0.46.6
+### 0.46.7
 - Export custom `PinInputFieldElementType` for supporting custom ref types in TypeScript
 
 ### 0.46.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "0.46.6",
+    "version": "0.46.7",
     "private": false,
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",

--- a/src/components/PinInputField/PinInputField.tsx
+++ b/src/components/PinInputField/PinInputField.tsx
@@ -19,7 +19,7 @@ type PinInputFieldCustomProps = {
     focusFirstInputOnReset ? : boolean;
 };
 
-export type PinInputFieldElementType = HTMLDivElement & { reset: () => void };
+export type PinInputFieldElementType = HTMLDivElement & { reset?: () => void };
 export type PinInputFieldProps = Omit<CommonAndHTMLProps<PinInputFieldElementType>, keyof PinInputFieldCustomProps> &
     PinInputFieldCustomProps;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,7 @@ export {
 } from "./components/Notification";
 
 // PIN INPUT FIELD  ///////////////////////////////////////////////////////////
-export { PinInputField, PinInputStyled, PinInputFieldProps } from "./components/PinInputField";
+export { PinInputField, PinInputStyled,PinInputFieldElementType, PinInputFieldProps } from "./components/PinInputField";
 
 // PROGRESS BAR  //////////////////////////////////////////////////////////////
 export { ProgressBar, ProgressBarStyled, ProgressBarProps } from "./components/ProgressBar";


### PR DESCRIPTION
Changes:
- Export custom `PinInputFieldElementType` from the package for typesafe ref creation, refer #106  for usage.
- Make the `reset` property optional in `PinInputFieldElementType`