### PR TITLE
Fix focusFirstInputOnReset prop behaviour for PinInputField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
-### 0.46.6
+### 0.46.8
+- Fix `focusFirstInputOnReset` prop behaviour to properly set focus on first input on reset
+
+### 0.46.7
 - Export custom `PinInputFieldElementType` for supporting custom ref types in TypeScript
 
 ### 0.46.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "0.46.6",
+    "version": "0.46.8",
     "private": false,
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.js",

--- a/src/components/PinInputField/PinInputField.tsx
+++ b/src/components/PinInputField/PinInputField.tsx
@@ -19,7 +19,7 @@ type PinInputFieldCustomProps = {
     focusFirstInputOnReset ? : boolean;
 };
 
-export type PinInputFieldElementType = HTMLDivElement & { reset?: () => void };
+export type PinInputFieldElementType = HTMLDivElement & { reset: () => void };
 export type PinInputFieldProps = Omit<CommonAndHTMLProps<PinInputFieldElementType>, keyof PinInputFieldCustomProps> &
     PinInputFieldCustomProps;
 

--- a/src/components/PinInputField/PinInputField.tsx
+++ b/src/components/PinInputField/PinInputField.tsx
@@ -105,7 +105,7 @@ export const PinInputField = React.forwardRef(
                 focus(0);
                 setFocusedIndex(0);
             }
-        }, [length, onChange, focus]);
+        }, [length, onChange, focus, focusFirstInputOnReset]);
 
         const setValue = useCallback(
             (value: string, index: number) => {


### PR DESCRIPTION
Changes:
- Fix `focusFirstInputOnReset` prop behaviour for `PinInputField` by adding it as a dependency to the reset handler, so it properly reflects the behaviour of opting out of setting focus on the first input on reset