### PR TITLE
Export types from fictoan-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "private": false,
     "description": "",
     "type": "module",
@@ -12,6 +12,7 @@
     ],
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
+    "types" : "./dist/index.d.ts",
     "exports": {
         ".": {
             "import": "./dist/index.js",


### PR DESCRIPTION
Currently, `types` are not exported from `fictoan-react`.  This PR fixes that