### PR TITLE
Update build types in ThemeProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.3.6
+
+- Fix type checks and `useClient` directive for vite build
+
 ## 1.3.3
 
 - Fix wrong theme values for `kbd` 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "1.3.3",
+    "version": "1.3.6",
     "private": false,
     "description": "",
     "type": "module",

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -4,7 +4,7 @@ import { Element } from "../Element/Element";
 import { Div } from "../Element/Tags";
 import { CommonAndHTMLProps, SpacingTypes } from "../Element/constants";
 
-import { useClickOutside } from "@/hooks/UseClickOutside";
+import { useClickOutside } from "../../hooks/UseClickOutside";
 
 import "./drawer.css";
 

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -8,7 +8,7 @@ export type ThemeProviderElementType = HTMLDivElement;
 export type RenderProps = () => JSX.Element;
 
 const storageKey = "fictoan-theme";
-const themes = ["light", "dark"];
+const themes = ["theme-light", "theme-dark"];
 
 const ThemeContext = React.createContext<UseThemeProps | undefined>(undefined);
 const defaultContext: UseThemeProps = { setTheme: (_) => {} };
@@ -37,17 +37,17 @@ export const ThemeProvider = React.forwardRef(
         const setTheme = useCallback(
             (newTheme: any) => {
                 if (!themes.includes(newTheme)) {
-                    newTheme = "light";
+                    newTheme = "theme-light";
                 }
                 document.documentElement.className = "";
-                setThemeState(`theme-${newTheme}`);
-                document.documentElement.classList.add(`theme-${newTheme}`);
+                setThemeState(`${newTheme}`);
+                document.documentElement.classList.add(`${newTheme}`);
                 if (!shouldRender) {
                     setShouldRender(true);
                 }
                 // Save to storage
                 try {
-                    localStorage.setItem(storageKey, `theme-${newTheme}`);
+                    localStorage.setItem(storageKey, `${newTheme}`);
                 } catch (e) {
                     // Unsupported
                 }
@@ -56,9 +56,8 @@ export const ThemeProvider = React.forwardRef(
         );
 
         useEffect(() => {
-            if (currentTheme) {
-                setTheme(currentTheme);
-            }
+            let theme = getTheme(storageKey, "NA");
+            theme === "NA" ? setTheme(currentTheme) : setTheme(theme);
         }, [currentTheme]);
 
         return (


### PR DESCRIPTION
`1.3.5` build did not include component types and `useClient` directive for Next 14 apps.

This version will build using CI/CD pipeline and fix these issues