### PR TITLE
v1.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.10.4
+- Fix text alignment for `stringRight` in `InputField`
+- Simplified markup for `Checkbox`, `Switch`, `Select`, `RadioButton`, `RadioGroup` and `RadioTabGroup`, where `name` 
+and `value` props are inherited from `id` if not present.
 
 ## 1.10.3
 - Fix CSS variable mismatch for  `Sidebar`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fictoan-react",
-    "version": "1.10.3",
+    "version": "1.10.4",
     "private": false,
     "description": "A full-featured, designer-friendly, yet performant framework with plain-English props and focus on rapid iteration.",
     "repository": {

--- a/src/components/Form/Checkbox/Checkbox.tsx
+++ b/src/components/Form/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 // FRAMEWORK ===========================================================================================================
-import React from "react";
+import React, { useMemo } from "react";
 
 // FICTOAN =============================================================================================================
 import { Element } from "../../Element/Element";
@@ -15,10 +15,23 @@ export type CheckboxElementType = HTMLInputElement;
 export type CheckboxProps = Omit<BaseInputComponentProps<CheckboxElementType>, "as">;
 
 // COMPONENT ///////////////////////////////////////////////////////////////////////////////////////////////////////////
-export const Checkbox = React.forwardRef(({ ...props }: CheckboxProps, ref: React.Ref<CheckboxElementType>) => {
-    return (
-        <Element<CheckboxElementType> as="div" data-checkbox ref={ref}>
-            <BaseInputComponent as="input" type="checkbox" {...props} />
-        </Element>
-    );
-});
+export const Checkbox = React.forwardRef(
+    ({ id, name, value, ...props }: CheckboxProps, ref: React.Ref<CheckboxElementType>) => {
+        // Use ID as default for name and value if they’re not provided
+        const derivedName = useMemo(() => name || id, [name, id]);
+        const derivedValue = useMemo(() => value || id, [value, id]);
+
+        return (
+            <Element<CheckboxElementType> as="div" data-checkbox ref={ref}>
+                <BaseInputComponent
+                    as="input"
+                    type="checkbox"
+                    id={id}
+                    name={derivedName}
+                    value={derivedValue}
+                    {...props}
+                />
+            </Element>
+        );
+    }
+);

--- a/src/components/Form/Checkbox/Switch.tsx
+++ b/src/components/Form/Checkbox/Switch.tsx
@@ -1,5 +1,5 @@
 // FRAMEWORK ===========================================================================================================
-import React from "react";
+import React, { useMemo } from "react";
 
 // FICTOAN =============================================================================================================
 import { Element } from "../../Element/Element";
@@ -21,10 +21,21 @@ export type SwitchProps = Omit<BaseInputComponentProps<SwitchElementType>, keyof
 
 // COMPONENT ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 export const Switch = React.forwardRef(
-    ({ size = "medium", ...props }: SwitchProps, ref: React.Ref<SwitchElementType>) => {
+    ({ id, name, value, size = "medium", ...props }: SwitchProps, ref: React.Ref<SwitchElementType>) => {
+        // Use ID as default for name and value if they’re not provided
+        const derivedName = useMemo(() => name || id, [name, id]);
+        const derivedValue = useMemo(() => value || id, [value, id]);
+
         return (
             <Element<SwitchElementType> as="div" data-switch ref={ref} className={`size-${size}`}>
-                <BaseInputComponent as="input" type="checkbox" {...props} />
+                <BaseInputComponent
+                    as="input"
+                    type="checkbox"
+                    id={id}
+                    name={derivedName}
+                    value={derivedValue}
+                    {...props}
+                />
             </Element>
         );
     }

--- a/src/components/Form/InputField/input-field.css
+++ b/src/components/Form/InputField/input-field.css
@@ -75,7 +75,7 @@ input[data-input-field] {
     position              : absolute;
     inset                 : 0;
     width                 : 100%;
-    padding               : calc(var(--input-padding) - (var(--global-border-width)*2));
+    padding               : calc(var(--input-padding) - (var(--global-border-width) * 2));
     pointer-events        : none;
     display               : grid;
     grid-template-rows    : 1fr;
@@ -86,15 +86,24 @@ input[data-input-field] {
     justify-content       : space-between;
 }
 
+/* ELEMENTS ON THE LEFT/RIGHT =============================================== */
 [data-input-side-element] {
     line-height : 0;
     white-space : nowrap;
 
+    &.left { grid-area : leftElement; }
+    &.right { grid-area : rightElement; }
+
+    /* When the element is text --------------------------------------------- */
     &.is-text {
         &.left { min-width : var(--side-element-left-width); }
-        &.right { min-width : var(--side-element-right-width); }
+        &.right {
+            min-width  : var(--side-element-right-width);
+            text-align : right;
+        }
     }
 
+    /* When the element is an icon ------------------------------------------ */
     &.is-icon {
         width        : var(--input-icon-size);
         height       : var(--input-icon-size);
@@ -102,9 +111,6 @@ input[data-input-field] {
         stroke-width : 2px;
     }
 }
-
-[data-input-side-element].left { grid-area : leftElement; }
-[data-input-side-element].right { grid-area : rightElement; }
 
 /* PADDING LEFT SIDE ======================================================== */
 /* Padding when there is no icon or text ------------------------------------ */

--- a/src/components/Form/RadioButton/RadioButton.tsx
+++ b/src/components/Form/RadioButton/RadioButton.tsx
@@ -1,5 +1,5 @@
 // FRAMEWORK ===========================================================================================================
-import React from "react";
+import React, { useMemo } from "react";
 
 // FICTOAN =============================================================================================================
 import { Element } from "../../Element/Element";
@@ -14,11 +14,19 @@ import { RadioButtonProps, RadioButtonElementType } from "./constants";
 // COMPONENT ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 export const RadioButton = React.forwardRef(
     ({
+         id,
+         name,
+         value,
          onClick,
          ...props
      }: RadioButtonProps,
      ref: React.Ref<RadioButtonElementType>,
     ) => {
+        // Use ID as default for value if not provided
+        // Note: name should typically come from RadioGroup
+        const derivedValue = useMemo(() => value || id, [value, id]);
+        const derivedName = useMemo(() => name || id, [name, id]);
+
         return (
             <Element<RadioButtonElementType>
                 as="div"
@@ -32,6 +40,9 @@ export const RadioButton = React.forwardRef(
                 <BaseInputComponent
                     as="input"
                     type="radio"
+                    id={id}
+                    name={derivedName}
+                    value={derivedValue}
                     {...props}
                 />
             </Element>

--- a/src/components/Form/RadioButton/RadioGroup.tsx
+++ b/src/components/Form/RadioButton/RadioGroup.tsx
@@ -1,16 +1,35 @@
-import React from "react";
+// FRAMEWORK ===========================================================================================================
+import React, { useMemo } from "react";
 
+// FICTOAN =============================================================================================================
 import { RadioButton } from "./RadioButton";
 import { Element } from "../../Element/Element";
 import { BaseInputComponent } from "../BaseInputComponent/BaseInputComponent";
 
+// TYPES ===============================================================================================================
 import { RadioGroupProps } from "./constants";
 
-const RadioGroupOptions = ({ options, defaultValue, required, ...props }: RadioGroupProps) => {
+// COMPONENT ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+const RadioGroupOptions = ({ id, name, options, defaultValue, required, ...props }: RadioGroupProps) => {
+    // Use ID as default for name if not provided
+    const derivedName = useMemo(() => name || id, [name, id]);
+
     return (
         <Element as="div" required={required}>
             {options.map((option, index) => {
-                return <RadioButton key={index} {...props} {...option} />;
+                const { id: optionId, ...optionProps } = option;
+                // Derive option id if not provided
+                const finalId = optionId || `${id}-option-${index}`;
+
+                return (
+                    <RadioButton
+                        key={finalId}
+                        {...props}
+                        {...optionProps}
+                        id={finalId}
+                        name={derivedName} // Pass group's name to all radio buttons
+                    />
+                );
             })}
         </Element>
     );

--- a/src/components/Form/RadioButton/RadioTabGroup.tsx
+++ b/src/components/Form/RadioButton/RadioTabGroup.tsx
@@ -1,25 +1,42 @@
-import React from "react";
+// FRAMEWORK ===========================================================================================================
+import React, { useMemo } from "react";
 
+// FICTOAN =============================================================================================================
 import { Div } from "../../Element/Tags";
 import { BaseInputComponent } from "../BaseInputComponent/BaseInputComponent";
-import { RadioTabGroupProps, RadioGroupProps, RadioButtonElementType } from "./constants";
 
+// STYLES ==============================================================================================================
 import "./radio-tab-group.css";
 
-const RadioTabGroupOptions = ({ options, defaultValue, value, required, ...props }: RadioGroupProps) => {
+// TYPES ===============================================================================================================
+import { RadioTabGroupProps, RadioGroupProps, RadioButtonElementType } from "./constants";
+
+// COMPONENT ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+const RadioTabGroupOptions = ({ id, name, options, defaultValue, value, required, ...props }: RadioGroupProps) => {
+    // Use ID as default for name if not provided
+    const derivedName = useMemo(() => name || id, [name, id]);
+
     return (
-        <Div data-radio-tab-group name={props.name} required={required}>
-            {options.map((option) => (
-                <React.Fragment key={option.id}>
-                    <input
-                        type="radio"
-                        {...props}
-                        {...option}
-                        checked={value === option.value}
-                    />
-                    <label htmlFor={option.id}>{option.label}</label>
-                </React.Fragment>
-            ))}
+        <Div data-radio-tab-group name={derivedName} required={required}>
+            {options.map((option, index) => {
+                const { id: optionId, ...optionProps } = option;
+                // Derive option id if not provided
+                const finalId = optionId || `${id}-option-${index}`;
+
+                return (
+                    <React.Fragment key={finalId}>
+                        <input
+                            type="radio"
+                            {...props}
+                            {...optionProps}
+                            id={finalId}
+                            name={derivedName}
+                            checked={value === option.value}
+                        />
+                        <label htmlFor={finalId}>{option.label}</label>
+                    </React.Fragment>
+                );
+            })}
         </Div>
     );
 };

--- a/src/components/Form/Select/Select.tsx
+++ b/src/components/Form/Select/Select.tsx
@@ -1,11 +1,15 @@
-import React from "react";
+// FRAMEWORK ===========================================================================================================
+import React, { useMemo } from "react";
 
+// FICTOAN =============================================================================================================
 import { Element } from "../../Element/Element";
-import { BaseInputComponent } from "../BaseInputComponent/BaseInputComponent";
 import { Div } from "../../Element/Tags";
+import { BaseInputComponent } from "../BaseInputComponent/BaseInputComponent";
 
+// STYLES ==============================================================================================================
 import "./select.css";
 
+// TYPES ===============================================================================================================
 import {
     OptionProps,
     OptGroupProps,
@@ -14,15 +18,28 @@ import {
     SelectElementType,
 } from "./constants";
 
-const SelectWithOptions = ({ options, className, ...props }: SelectProps) => {
+// COMPONENT ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+const SelectWithOptions = ({ id, name, options, className, ...props }: SelectProps) => {
+    // Use ID as default for name if it’s not provided
+    const derivedName = useMemo(() => name || id, [name, id]);
+
     const renderOption = (option: OptionProps) => (
-        <Element<OptionElementType> as="option" key={option.value} value={option.value} disabled={option.disabled}>
+        <Element<OptionElementType>
+            as="option"
+            key={option.value}
+            value={option.value}
+            disabled={option.disabled}
+        >
             {option.label}
         </Element>
     );
 
     const renderOptGroup = (group: OptGroupProps) => (
-        <Element<HTMLOptGroupElement> as="optgroup" key={group.label} label={group.label}>
+        <Element<HTMLOptGroupElement>
+            as="optgroup"
+            key={group.label}
+            label={group.label}
+        >
             {/* @ts-ignore */}
             {group.options.map(renderOption)}
         </Element>
@@ -30,7 +47,12 @@ const SelectWithOptions = ({ options, className, ...props }: SelectProps) => {
 
     return (
         <Div data-select className={className} disabled={props.disabled}>
-            <Element<SelectElementType> as="select" {...props}>
+            <Element<SelectElementType>
+                as="select"
+                id={id}
+                name={derivedName}
+                {...props}
+            >
                 {options.map((option) =>
                     // @ts-ignore
                     "options" in option ? renderOptGroup(option) : renderOption(option)
@@ -42,6 +64,10 @@ const SelectWithOptions = ({ options, className, ...props }: SelectProps) => {
 
 export const Select = React.forwardRef((props: SelectProps, ref: React.Ref<SelectElementType>) => {
     return (
-        <BaseInputComponent<SelectElementType> as={SelectWithOptions} ref={ref} {...props} />
+        <BaseInputComponent<SelectElementType>
+            as={SelectWithOptions}
+            ref={ref}
+            {...props}
+        />
     );
 });


### PR DESCRIPTION
- Fix text alignment for `stringRight` in `InputField`
- Simplified markup for `Checkbox`, `Switch`, `Select`, `RadioButton`, `RadioGroup` and `RadioTabGroup`, where `name` 
and `value` props are inherited from `id` if not present.